### PR TITLE
Add the octokit gem as a dependency for Ablecop

### DIFF
--- a/ablecop/ablecop.gemspec
+++ b/ablecop/ablecop.gemspec
@@ -27,6 +27,9 @@ Gem::Specification.new do |spec|
   # Pronto posts feedback from its runners to Github.
   spec.add_dependency "pronto", "~> 0.6.0"
 
+  # Octokit is required for updating commits / pull requests.
+  spec.add_dependency "octokit", "~> 4.3.0"
+
   # Rubocop is a static code analyzer based on our Ruby style guide.
   spec.add_dependency "rubocop", "~> 0.39.0"
   spec.add_dependency "pronto-rubocop", "~> 0.6.2"

--- a/ablecop/lib/ablecop/tasks/ablecop.rake
+++ b/ablecop/lib/ablecop/tasks/ablecop.rake
@@ -1,4 +1,5 @@
 require "pronto"
+require "octokit"
 
 desc "Runs ablecop automatted code review on CircleCI"
 namespace :ablecop do


### PR DESCRIPTION
This branch adds the [octokit](https://github.com/octokit/octokit.rb) gem as a dependency in Ablecop's gemspec. This gem is needed by Pronto to post updates to commits and pull requests, so we should make sure projects using this gem have octokit installed and we're explicitly requiring it.