### PR TITLE
Upgrade Rubocop and Brakeman, and bump Ablecop to version 0.2.0

### DIFF
--- a/ablecop/ablecop.gemspec
+++ b/ablecop/ablecop.gemspec
@@ -51,11 +51,11 @@ MSG
   spec.add_dependency "octokit", "~> 4.3.0"
 
   # Rubocop is a static code analyzer based on our Ruby style guide.
-  spec.add_dependency "rubocop", "~> 0.39.0"
+  spec.add_dependency "rubocop", "~> 0.40.0"
   spec.add_dependency "pronto-rubocop", "~> 0.6.2"
 
   # Brakeman scans for security vulenerabilities.
-  spec.add_dependency "brakeman", "~> 3.2"
+  spec.add_dependency "brakeman", "~> 3.3.0"
   spec.add_dependency "pronto-brakeman", "~> 0.6.0"
 
   # Fasterer will suggest some speed improvements.

--- a/ablecop/config/rubocop.yml
+++ b/ablecop/config/rubocop.yml
@@ -1060,7 +1060,7 @@ Lint/DefEndAlignment:
 
 # Checks for unused block arguments
 Lint/UnusedBlockArgument:
-  IgnoreEmptyBlocks: true
+  AllowUnusedKeywordArguments: false
 
 # Checks for unused method arguments.
 Lint/UnusedMethodArgument:

--- a/ablecop/lib/ablecop/version.rb
+++ b/ablecop/lib/ablecop/version.rb
@@ -1,4 +1,4 @@
 # :NO_DOC:
 module Ablecop
-  VERSION = "0.1.0".freeze
+  VERSION = "0.2.0".freeze
 end


### PR DESCRIPTION
This branch updates Rubocop and Brakeman to the latest versions, and bumps up the version of the Ablecop gem to 0.2.0 to account for the recent changes that have been merged.